### PR TITLE
🎯 Issue #18: 担当者・プロジェクト別フィルタ機能

### DIFF
--- a/src/components/ClientDashboard.tsx
+++ b/src/components/ClientDashboard.tsx
@@ -16,7 +16,18 @@ export function ClientDashboard({
 }: ClientDashboardProps) {
   // Custom hooks使用
   const { tasks, loading, error, lastUpdated } = useTasks();
-  const { currentFilter, setCurrentFilter, filteredTasks, stats } = useTaskFilter(tasks);
+  const { 
+    currentFilter, 
+    setCurrentFilter, 
+    assigneeFilter,
+    setAssigneeFilter,
+    projectFilter,
+    setProjectFilter,
+    filteredTasks, 
+    stats,
+    availableAssignees,
+    availableProjects
+  } = useTaskFilter(tasks);
 
   // フィルタクリックハンドラー（useCallbackで最適化）
   const handleFilterClick = useCallback((filter: FilterType) => {
@@ -62,47 +73,144 @@ export function ClientDashboard({
           タスク管理ダッシュボード 📋
         </h1>
 
-        <div className="mb-4 flex justify-between items-center">
-          <div className="space-x-2">
-            <button
-              onClick={() => handleFilterClick('all')}
-              className={`px-2 py-1 rounded text-sm font-medium transition-all duration-200 ${
-                currentFilter === 'all'
-                  ? 'bg-green-200 text-green-900 shadow-md'
-                  : 'bg-green-100 text-green-800 hover:bg-green-200 hover:shadow-md'
-              }`}
-            >
-              📊 取得: {stats.totalTasks}件
-            </button>
-            
-            <button
-              onClick={() => handleFilterClick('overdue')}
-              className={`px-2 py-1 rounded text-sm font-medium transition-all duration-200 ${
-                currentFilter === 'overdue'
-                  ? 'bg-red-200 text-red-900 shadow-md'
-                  : 'bg-red-100 text-red-800 hover:bg-red-200 hover:shadow-md'
-              }`}
+        {/* 🎨 統合フィルタエリア */}
+        <div className="mb-6 space-y-4">
+          {/* メインフィルタ行 */}
+          <div className="flex flex-wrap gap-3 items-center justify-between">
+            {/* ステータスフィルタボタン群 */}
+            <div className="flex flex-wrap gap-2 items-center">
+              <button
+                onClick={() => handleFilterClick('all')}
+                className={`px-3 py-2 rounded-lg text-sm font-medium transition-all duration-200 ${
+                  currentFilter === 'all'
+                    ? 'bg-green-500 text-white shadow-lg transform scale-105'
+                    : 'bg-green-100 text-green-800 hover:bg-green-200 hover:shadow-md'
+                }`}
+              >
+                📊 全て: {stats.totalTasks}件
+              </button>
+              
+              <button
+                onClick={() => handleFilterClick('overdue')}
+                className={`px-3 py-2 rounded-lg text-sm font-medium transition-all duration-200 ${
+                  currentFilter === 'overdue'
+                    ? 'bg-red-500 text-white shadow-lg transform scale-105'
+                    : 'bg-red-100 text-red-800 hover:bg-red-200 hover:shadow-md'
+                }`}
+              >
+                🔥 期限切れ: {stats.overdueTasks}件
+              </button>
+              
+              <button
+                onClick={() => handleFilterClick('due-tomorrow')}
+                className={`px-3 py-2 rounded-lg text-sm font-medium transition-all duration-200 ${
+                  currentFilter === 'due-tomorrow'
+                    ? 'bg-yellow-500 text-white shadow-lg transform scale-105'
+                    : 'bg-yellow-100 text-yellow-800 hover:bg-yellow-200 hover:shadow-md'
+                }`}
+              >
+                ⚠️ 明日期限: {stats.dueTomorrowTasks}件
+              </button>
 
-            >
-              🔥 期限切れ: {stats.overdueTasks}件
-            </button>
-            
-            <button
-              onClick={() => handleFilterClick('due-tomorrow')}
-              className={`px-2 py-1 rounded text-sm font-medium transition-all duration-200 ${
-                currentFilter === 'due-tomorrow'
-                  ? 'bg-yellow-200 text-yellow-900 shadow-md'
-                  : 'bg-yellow-100 text-yellow-800 hover:bg-yellow-200 hover:shadow-md'
-              }`}
+              {/* セパレーター */}
+              <div className="h-8 w-px bg-gray-300 mx-1"></div>
 
-            >
-              ⚠️ 明日期限: {stats.dueTomorrowTasks}件
-            </button>
+              {/* ドロップダウンフィルタ */}
+              <div className="flex flex-wrap gap-2 items-center">
+                <select 
+                  value={assigneeFilter}
+                  onChange={(e) => setAssigneeFilter(e.target.value)}
+                  className={`px-3 py-2 text-sm border rounded-lg bg-white transition-all duration-200 ${
+                    assigneeFilter !== 'all' 
+                      ? 'border-purple-500 bg-purple-50 text-purple-800 shadow-md' 
+                      : 'border-gray-300 hover:border-gray-400 focus:border-blue-500'
+                  } focus:outline-none focus:ring-2 focus:ring-blue-200`}
+                >
+                  <option value="all">👤 全担当者</option>
+                  {availableAssignees.filter(name => name !== 'all').map(name => (
+                    <option key={name} value={name}>👤 {name}</option>
+                  ))}
+                </select>
+
+                <select 
+                  value={projectFilter}
+                  onChange={(e) => setProjectFilter(e.target.value)}
+                  className={`px-3 py-2 text-sm border rounded-lg bg-white transition-all duration-200 ${
+                    projectFilter !== 'all' 
+                      ? 'border-indigo-500 bg-indigo-50 text-indigo-800 shadow-md' 
+                      : 'border-gray-300 hover:border-gray-400 focus:border-blue-500'
+                  } focus:outline-none focus:ring-2 focus:ring-blue-200`}
+                >
+                  <option value="all">📁 全プロジェクト</option>
+                  {availableProjects.filter(key => key !== 'all').map(key => (
+                    <option key={key} value={key}>📁 {key}</option>
+                  ))}
+                </select>
+
+                {/* リセットボタン */}
+                {(assigneeFilter !== 'all' || projectFilter !== 'all') && (
+                  <button
+                    onClick={() => {
+                      setAssigneeFilter('all');
+                      setProjectFilter('all');
+                    }}
+                    className="px-3 py-2 text-sm bg-gray-500 text-white rounded-lg hover:bg-gray-600 transition-all duration-200 shadow-md hover:shadow-lg"
+                    title="フィルタをリセット"
+                  >
+                    🔄 リセット
+                  </button>
+                )}
+              </div>
+            </div>
+
+            {/* 右側：更新時刻 */}
+            <div className="text-sm text-gray-500 flex items-center gap-2">
+              <span className="text-gray-400">🕒</span>
+              最終更新: {lastUpdated.toLocaleString('ja-JP')}
+            </div>
           </div>
-          
-          <div className="text-sm text-gray-500">
-            最終更新: {lastUpdated.toLocaleString('ja-JP')}
-          </div>
+
+          {/* フィルタ適用状況バー */}
+          {(assigneeFilter !== 'all' || projectFilter !== 'all' || currentFilter !== 'all') && (
+            <div className="bg-gradient-to-r from-blue-50 to-purple-50 border border-blue-200 rounded-lg p-3">
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-3">
+                  <span className="text-blue-700 font-medium">🔍 適用中のフィルタ:</span>
+                  <div className="flex flex-wrap gap-2">
+                    {currentFilter !== 'all' && (
+                      <span className="bg-blue-100 text-blue-800 px-2 py-1 rounded text-xs font-medium">
+                        {currentFilter === 'overdue' && '🔥 期限切れ'}
+                        {currentFilter === 'due-tomorrow' && '⚠️ 明日期限'}
+                      </span>
+                    )}
+                    {assigneeFilter !== 'all' && (
+                      <span className="bg-purple-100 text-purple-800 px-2 py-1 rounded text-xs font-medium">
+                        👤 {assigneeFilter}
+                      </span>
+                    )}
+                    {projectFilter !== 'all' && (
+                      <span className="bg-indigo-100 text-indigo-800 px-2 py-1 rounded text-xs font-medium">
+                        📁 {projectFilter}
+                      </span>
+                    )}
+                  </div>
+                  <span className="text-blue-600 font-semibold">
+                    {stats.filteredCount}件 / {stats.totalTasks}件
+                  </span>
+                </div>
+                <button
+                  onClick={() => {
+                    handleFilterClick('all');
+                    setAssigneeFilter('all');
+                    setProjectFilter('all');
+                  }}
+                  className="text-blue-600 hover:text-blue-800 hover:underline text-sm font-medium"
+                >
+                  すべてクリア
+                </button>
+              </div>
+            </div>
+          )}
         </div>
 
         {currentFilter !== 'all' && (

--- a/src/hooks/useTaskFilter.tsx
+++ b/src/hooks/useTaskFilter.tsx
@@ -3,35 +3,89 @@ import type { Task } from '../types';
 
 export type FilterType = 'all' | 'overdue' | 'due-tomorrow';
 
-// タスクフィルタリングのカスタムフック
+// タスクフィルタリングのカスタムフック（担当者・プロジェクトフィルタ拡張版）
 export function useTaskFilter(tasks: Task[]) {
-  const [currentFilter, setCurrentFilter] = useState<FilterType>('all');
+  // ✨ 3つのフィルタ状態を管理
+  const [statusFilter, setStatusFilter] = useState<FilterType>('all');
+  const [assigneeFilter, setAssigneeFilter] = useState<string>('all');
+  const [projectFilter, setProjectFilter] = useState<string>('all');
 
-  // フィルタリング処理（useMemoで最適化）
+  // 🔍 利用可能な担当者リストを動的生成（MEMBER_KEYSベース）
+  const availableAssignees = useMemo(() => {
+    const assignees = new Set<string>();
+    tasks.forEach(task => {
+      if (task.assigneeName) {
+        assignees.add(task.assigneeName);
+      }
+    });
+    return ['all', ...Array.from(assignees).sort()];
+  }, [tasks]);
+
+  // 📁 利用可能なプロジェクトリストを動的生成（PROJECT_KEYSベース）
+  const availableProjects = useMemo(() => {
+    const projects = new Set<string>();
+    tasks.forEach(task => {
+      projects.add(task.projectKey);
+    });
+    return ['all', ...Array.from(projects).sort()];
+  }, [tasks]);
+
+  // 🎯 複合フィルタリング処理（useMemoで最適化）
   const filteredTasks = useMemo(() => {
-    switch (currentFilter) {
-      case 'overdue':
-        return tasks.filter(task => task.isOverdue);
-      case 'due-tomorrow':
-        return tasks.filter(task => task.isDueTomorrow);
-      case 'all':
-      default:
-        return tasks;
-    }
-  }, [tasks, currentFilter]);
+    return tasks.filter(task => {
+      // 1. ステータスフィルタ（既存ロジック）
+      let matchesStatus = true;
+      switch (statusFilter) {
+        case 'overdue':
+          matchesStatus = task.isOverdue;
+          break;
+        case 'due-tomorrow':
+          matchesStatus = task.isDueTomorrow;
+          break;
+        case 'all':
+        default:
+          matchesStatus = true;
+          break;
+      }
 
-  // 統計計算（useMemoで最適化）
+      // 2. 担当者フィルタ（新規）
+      const matchesAssignee = assigneeFilter === 'all' || 
+        task.assigneeName === assigneeFilter;
+
+      // 3. プロジェクトフィルタ（新規）
+      const matchesProject = projectFilter === 'all' || 
+        task.projectKey === projectFilter;
+
+      return matchesStatus && matchesAssignee && matchesProject;
+    });
+  }, [tasks, statusFilter, assigneeFilter, projectFilter]);
+
+  // 📊 統計計算（useMemoで最適化）
   const stats = useMemo(() => ({
     totalTasks: tasks.length,
     overdueTasks: tasks.filter(task => task.isOverdue).length,
     dueTomorrowTasks: tasks.filter(task => task.isDueTomorrow).length,
-    completedTasks: tasks.filter(task => task.status === '完了').length
-  }), [tasks]);
+    completedTasks: tasks.filter(task => task.status === '完了').length,
+    filteredCount: filteredTasks.length
+  }), [tasks, filteredTasks]);
 
   return {
-    currentFilter,
-    setCurrentFilter,
+    // ステータスフィルタ（既存互換性のため）
+    currentFilter: statusFilter,
+    setCurrentFilter: setStatusFilter,
+    
+    // 新規フィルタ
+    statusFilter,
+    setStatusFilter,
+    assigneeFilter,
+    setAssigneeFilter,
+    projectFilter,
+    setProjectFilter,
+    
+    // データ
     filteredTasks,
-    stats
+    stats,
+    availableAssignees,
+    availableProjects
   };
 }


### PR DESCRIPTION
## Summary
Issue #18の担当者・プロジェクト別フィルタ機能を実装しました。

## ✨ 新機能
- **👤 担当者フィルタ**: ドロップダウンで担当者別絞り込み
- **📁 プロジェクトフィルタ**: ドロップダウンでプロジェクト別絞り込み  
- **🔄 複合フィルタ**: 既存ボタン + 新規ドロップダウンの組み合わせ対応（AND条件）
- **📊 動的選択肢**: 環境変数`MEMBER_KEYS`/`PROJECT_KEYS`ベースの自動生成

## 🎨 UIデザイン
- **統合フィルタエリア**: 全機能を一箇所に集約
- **横並びレイアウト**: `[📊全て] [🔥期限切れ] [⚠️明日期限] | [👤担当者▼] [📁プロジェクト▼] [🔄リセット]`
- **視覚的フィードバック**: アクティブ状態とフィルタ適用状況の表示
- **レスポンシブ対応**: モバイル～PC対応

## 🚀 技術仕様
- **useTaskFilter hook拡張**: 3つのフィルタ状態管理
- **パフォーマンス最適化**: `useMemo`による計算キャッシュ
- **既存互換性維持**: 後方互換性を保持
- **TypeScript型安全性**: 完全な型サポート

## Test plan
- [x] 既存ボタンフィルタが正常動作
- [x] 担当者ドロップダウンが正しい選択肢を表示
- [x] プロジェクトドロップダウンが正しい選択肢を表示
- [x] 複合フィルタのAND条件が正常動作
- [x] フィルタリセット機能が動作
- [x] レスポンシブデザインが維持
- [x] TypeScriptコンパイルエラーなし
- [x] 既存テストが全て通過
- [x] ESLint警告なし（テスト関連のwarningは除く）

🤖 Generated with [Claude Code](https://claude.ai/code)